### PR TITLE
bgTarget.range varies depending on units

### DIFF
--- a/device-data/types/pumpSettings.md
+++ b/device-data/types/pumpSettings.md
@@ -182,10 +182,18 @@ Each blood glucose target segment object in the array contains a subset of the f
 
 [ingestion, storage, client] An integer encoding the allowed deviation above or below the PWD's target blood glucose.
 
-	Numerical type: An integer value representing an allowed range +/- an associated target.
+	Numerical type:
+		mg/dL: Integer value representing a `mg/dL` value.
+		mmol/L: Floating point value representing a `mmol/L` value.
 	Range:
-		min: 0
-		max: 50
+		mg/dL:
+			min: `target` - this value > 0
+			max: `target` + this value <= 1000
+		mmol/L:
+			min: `target` - this value > 0.0
+			max: `target` + this value <= 55.0
+
+
 
 #### start
 

--- a/device-data/types/wizard.md
+++ b/device-data/types/wizard.md
@@ -160,10 +160,18 @@ Contains a subset of the following properties:
 
 [ingestion, storage, client] An integer encoding the allowed deviation above or below the PWD's target blood glucose.
 
-	Numerical type: An integer value representing an allowed range +/- an associated target.
+	Numerical type:
+		mg/dL: Integer value representing a `mg/dL` value.
+		mmol/L: Floating point value representing a `mmol/L` value.
 	Range:
-		min: 0
-		max: 50
+		mg/dL:
+			min: `target` - this value > 0
+			max: `target` + this value <= 1000
+		mmol/L:
+			min: `target` - this value > 0.0
+			max: `target` + this value <= 55.0
+
+
 
 #### Changelog for `bgTarget`
 

--- a/src/device-data/wizard.js
+++ b/src/device-data/wizard.js
@@ -114,10 +114,16 @@ var schema = {
         range: {
           summary: {
             description: '[ingestion, storage, client] An integer encoding the allowed deviation above or below the PWD\'s target blood glucose.',
-            numericalType: 'An integer value representing an allowed range +/- an associated target.',
+            numericalType: common.bgValueSummary.numericalType,
             range: {
-              min: 0,
-              max: 50
+              'mg/dL': {
+                min: '`target` - this value > 0',
+                max: '`target` + this value <= 1000'
+              },
+              'mmol/L': {
+                min: '`target` - this value > 0.0',
+                max: '`target` + this value <= 55.0'
+              }
             }
           }
         }


### PR DESCRIPTION
What it says on the tin. Previously `bgTarget.range` (for Animas pumps) was documented as being unitless, which made precisely zero sense...
